### PR TITLE
Add checkout and bump dependabot metadata to v3

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - uses: dependabot/fetch-metadata@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dependabot/fetch-metadata@v3
         id: metadata
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add an explicit Checkout step (actions/checkout@v4) to the auto-merge workflow and upgrade dependabot/fetch-metadata from v1 to v3. This ensures the repo is available to subsequent steps and uses the newer fetch-metadata action for improved compatibility.