### PR TITLE
Set PR_URL env in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,3 +19,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Expose PR_URL to the auto-merge job by mapping it to github.event.pull_request.html_url so the `gh pr merge` step can access the pull request URL during the merge operation.